### PR TITLE
fix(login): steps are not used with login flow when available

### DIFF
--- a/EcoSonar-API/services/loginProxyConfigurationService.js
+++ b/EcoSonar-API/services/loginProxyConfigurationService.js
@@ -70,7 +70,8 @@ LoginProxyConfigurationService.prototype.getLoginCredentials = async function (p
           loginInformations = {
             authentication_url: result.login.get('authentication_url'),
             username: result.login.get('username'),
-            password: result.login.get('password')
+            password: result.login.get('password'),
+            steps: result.login.get('steps')
           }
         }
       })


### PR DESCRIPTION
Bugfix : 

Je me suis rendu compte en utilisant l'authentification avec étapes que ça ne marchait pas.

Le fix est le suivant : récupérer les steps depuis la base mongo pour les utiliser.

Pour reproduire le bug : 
- ajouter des étapes dans l'authentification, et constater qu'elles ne sont pas appelées
- ou appeler directement le service de configuration de l'authentification et constater que les étapes ne sont pas retournées