### PR TITLE
Give choice to user to define basic auth or not

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/EcoSonar-API/routes/app.js
+++ b/EcoSonar-API/routes/app.js
@@ -37,12 +37,21 @@ app.use(helmet())
 
 const PORT = process.env.SWAGGER_PORT || 3002
 app.listen(PORT, () => loggerService.info(`Swagger in progress on port ${PORT}`))
-const passWord = process.env.ECOSONAR_USER_PASS || 'password'
+const passWord = process.env.ECOSONAR_USER_PASSWORD || 'password'
 const userName = process.env.ECOSONAR_USER_USERNAME || 'admin'
-app.use("/swagger",basicAuth({
-  users: {userName: passWord},
-  challenge: true,
-}), swaggerUi.serve, swaggerUi.setup(swaggerSpec))
+
+// Add choice to desable basic auth (to use on RP or other stuff)
+const basicAuthEnabled = process.env.ECOSONAR_BASIC_AUTH === 'true'
+
+if (basicAuthEnabled) {
+  app.use("/swagger", basicAuth({
+    users: {userName: passWord},
+    challenge: true,
+  }), swaggerUi.serve, swaggerUi.setup(swaggerSpec))
+} else {
+  app.use("/swagger", swaggerUi.serve, swaggerUi.setup(swaggerSpec))
+}
+
 
 
 const sonarqubeServerUrl = process.env.ECOSONAR_ENV_SONARQUBE_SERVER_URL || ''


### PR DESCRIPTION
Add choice to user to desable or enable basic auth on ECO SONAR API with a simple env variable in docker.

New var : ECOSONAR_BASIC_AUTH (boolean - true/false)

Change ECOSONAR_USER_PASS to ECOSONAR_USER_PASSWORD to be the same as README.md example Authentification in EcoSonar-API/README.md