### PR TITLE
fix: Use correct path for PGDATA variable in docker-compose & update …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     restart: unless-stopped
 
   db:
-    image: postgres:13
+    image: postgres:17
     container_name: ecosonar_postgresql
     networks:
       - sonarnet
@@ -75,7 +75,7 @@ services:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
       POSTGRES_DB: sonarqube
-      PGDATA: postgresql_data:/var/lib/postgresql/data/pgdata
+      PGDATA: /var/lib/postgresql/data/pgdata
     restart: unless-stopped
 
 networks:


### PR DESCRIPTION
PGDATA was not correctly set, causing to loose Postgres database when doing docker compose down, because it was not save in volume.

Update postgres to 17 (like creedengo-javascript).